### PR TITLE
fix: implement store hydration for all data stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env
+.env.local
+.env.*.local

--- a/src/components/menu/MenuComponent.tsx
+++ b/src/components/menu/MenuComponent.tsx
@@ -29,6 +29,15 @@ export const MenuComponent = () => {
   const navigate = useNavigate();
   const isAuth = useAuhtStore((state) => state.isAuth);
   const currentUser = useAuhtStore((state) => state.user);
+  const hasHydrated = useAuhtStore((state) => state.hasHydrated);
+  
+  // No renderizar hasta que el store esté hidratado
+  if (!hasHydrated) {
+    return null;
+  }
+  
+  const isAdmin = currentUser?.permissions.includes("ADMIN");
+  
   const workgroups = useWorkgroupStore((state) => state.workgroups);
   const setModal = useUiStore((state) => state.setModal);
   const modal = useUiStore((state) => state.modal);
@@ -38,8 +47,6 @@ export const MenuComponent = () => {
   const users = useUsersStore((state) => state.users);
 
   if (!isAuth) return null;
-
-  const isAdmin = currentUser?.permissions.includes("ADMIN");
   const workgroupsByRole = (): Workgroup[] => {
     if (isAdmin) return workgroups?.filter((wg) => wg.isActive) as Workgroup[];
 

--- a/src/firebase/firebase.config.ts
+++ b/src/firebase/firebase.config.ts
@@ -4,14 +4,14 @@ import { getAuth } from "firebase/auth";
 import { getDatabase } from "firebase/database";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyD0fmfbK_h059iA1zFcPJ3rUyZz7ucIZFU",
-  authDomain: "fastfirecrm.firebaseapp.com",
-  projectId: "fastfirecrm",
-  databaseURL: "https://fastfirecrm-default-rtdb.firebaseio.com",
-  storageBucket: "fastfirecrm.appspot.com",
-  messagingSenderId: "297602990290",
-  appId: "1:297602990290:web:dc60a9c2786c1754f22d0b",
-  measurementId: "G-XPC750D5LV"
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID
 };
 
 // Initialize Firebase

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -36,7 +36,7 @@ export const LoginPage = () => {
     if (signInResponse.result === "OK") {
       setIsAuth(true);
       setToken(await signInResponse.firebaseUser?.getIdToken() || '');
-      setNewUser(signInResponse.user as User)
+      setNewUser(signInResponse.user as User);
       navigate("/home");
     } else {
       setIsError(translateErrorMessage(signInResponse.error as string));

--- a/src/pages/tasks-groups/TasksGroupsPage.tsx
+++ b/src/pages/tasks-groups/TasksGroupsPage.tsx
@@ -18,6 +18,12 @@ export const TasksPage = () => {
   const modal = useUiStore((state) => state.modal);
   const setModal = useUiStore((state) => state.setModal);
   const user = useAuhtStore((state) => state.user);
+  const hasHydrated = useAuhtStore((state) => state.hasHydrated);
+  
+  // No renderizar hasta que el store esté hidratado
+  if (!hasHydrated) {
+    return null;
+  }
 
   useEffect(() => {
     setTabsValue(state?.goTo === "wg" ? 1 : 0);

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -60,6 +60,7 @@ export class AuthService {
       const userLoggedIn = await signInWithEmailAndPassword(auth, email, pass);
       const users: User[] =  Object.values((await get(ref(db, 'users'))).val());
       const userDB = users?.filter((u) => u.email === email)[0];
+      
       if (!userDB) {
         const msg = `El usuario "${email}" no está registrado.`;
         console.error(msg);

--- a/src/stores/auth/auth.store.ts
+++ b/src/stores/auth/auth.store.ts
@@ -6,9 +6,11 @@ interface AuthState {
   user: User | null;
   isAuth: boolean;
   token: string;
+  hasHydrated: boolean;
   setToken: (token: string) => void;
   setNewUser: (user: User) => void;
   setIsAuth: (isAuth: boolean) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 const customSessionStorage: StateStorage = {
@@ -29,12 +31,19 @@ export const useAuhtStore = create<AuthState>()(
       user: null,
       isAuth: false, // TODO DEJAR EN FALSE
       token: "",
+      hasHydrated: false,
       setToken: (token: string) => set(() => ({ token })),
-      setNewUser: (user: User) => set(() => ({ user })),
+      setNewUser: (user: User) => {
+        set(() => ({ user }));
+      },
       setIsAuth: (isAuth: boolean) => set(() => ({ isAuth })),
+      setHasHydrated: (hasHydrated: boolean) => set(() => ({ hasHydrated })),
     })), {
       name: 'auth-storage',
       storage: createJSONStorage(() => customSessionStorage),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
     }
   )
 );

--- a/src/stores/projects/projects.store.ts
+++ b/src/stores/projects/projects.store.ts
@@ -1,36 +1,46 @@
 import { create } from "zustand";
 import type { Project } from "../../interfaces/Project";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 import { onValue, ref } from "firebase/database";
 import { db } from "../../firebase/firebase.config";
 
 interface ProjectsState {
   projects: Project[] | null;
+  hasHydrated: boolean;
   loadProjects: () => void;
   setProjects: (projects: Project[]) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 export const useProjectsStore = create<ProjectsState>()(
-  devtools((set) => ({
-    projects: [],
-    loadProjects: async () => {
-      try {
-        const projects = ref(db, "projects");
-        onValue(projects, (snapshot) => {
-          const data = Object.values(snapshot.val()) as Project[] | [];
+  persist(
+    devtools((set) => ({
+      projects: [],
+      hasHydrated: false,
+      loadProjects: async () => {
+        try {
+          const projects = ref(db, "projects");
+          onValue(projects, (snapshot) => {
+            const data = Object.values(snapshot.val()) as Project[] | [];
 
-          if (data) {
-            set({ projects: data });
-          } else {
-            set({ projects: [] });
-          }
-        });
-      } catch (error) {
-        console.error("Error cargando propyectos desde store", { error });
-      }
-    },
-    setProjects: (projects: Project[]) => set(() => ({ projects })),
-  }))
+            if (data) {
+              set({ projects: data });
+            } else {
+              set({ projects: [] });
+            }
+          });
+        } catch (error) {
+          console.error("Error cargando proyectos desde store", { error });
+        }
+      },
+      setProjects: (projects: Project[]) => set(() => ({ projects })),
+      setHasHydrated: (hasHydrated: boolean) => set(() => ({ hasHydrated })),
+    })), {
+      name: 'projects-storage',
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+        state?.loadProjects();
+      },
+    }
+  )
 );
-
-useProjectsStore.getState().loadProjects();

--- a/src/stores/tasks/tasks.store.ts
+++ b/src/stores/tasks/tasks.store.ts
@@ -1,35 +1,45 @@
 import { create } from "zustand";
 import type { Task } from "../../interfaces/Task";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 import { onValue, ref } from "firebase/database";
 import { db } from "../../firebase/firebase.config";
 
 interface TasksState {
   tasks: Task[] | null;
+  hasHydrated: boolean;
   loadTasks: () => void;
   setTasks: (tasks: Task[]) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 export const useTasksStore = create<TasksState>()(
-  devtools((set) => ({
-    tasks: [],
-    loadTasks: async () => {
-      try {
-        const tasksRef = ref(db, "tasks");
-        onValue(tasksRef, (snapshot) => {
-          const data = Object.values(snapshot.val()) as Task[] || [];
-          
-          if (data) {
-            set({ tasks: data });
-          } else set({ tasks: [] });
-        });
-      } catch (error) {
-        console.error("Error cargando tareas desde store", { error });
-        set({ tasks: [] });
-      }
-    },
-    setTasks: (tasks: Task[]) => set(() => ({ tasks })),
-  }))
+  persist(
+    devtools((set) => ({
+      tasks: [],
+      hasHydrated: false,
+      loadTasks: async () => {
+        try {
+          const tasksRef = ref(db, "tasks");
+          onValue(tasksRef, (snapshot) => {
+            const data = Object.values(snapshot.val()) as Task[] || [];
+            
+            if (data) {
+              set({ tasks: data });
+            } else set({ tasks: [] });
+          });
+        } catch (error) {
+          console.error("Error cargando tareas desde store", { error });
+          set({ tasks: [] });
+        }
+      },
+      setTasks: (tasks: Task[]) => set(() => ({ tasks })),
+      setHasHydrated: (hasHydrated: boolean) => set(() => ({ hasHydrated })),
+    })), {
+      name: 'tasks-storage',
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+        state?.loadTasks();
+      },
+    }
+  )
 );
-
-useTasksStore.getState().loadTasks();

--- a/src/stores/users/users.store.ts
+++ b/src/stores/users/users.store.ts
@@ -1,35 +1,45 @@
 import { create } from "zustand";
 import { User } from "../../interfaces/User";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 import { onValue, ref } from "firebase/database";
 import { db } from "../../firebase/firebase.config";
 
 interface UsersState {
   users: User[] | null;
+  hasHydrated: boolean;
   loadUsers: () => void;
   setUsers: (users: User[]) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 export const useUsersStore = create<UsersState>()(
-  devtools((set) => ({
-    users: [],
-    loadUsers: async () => {
-      try {
-        const usersRef = ref(db, "users");
-        onValue(usersRef, (snapshot) => {
-          const data = Object.values(snapshot.val()) as User[] || [];
-  
-          if (data) {
-            set({users: data});
-          } else set({users:[]});
-        });
-      } catch (error) {
-        console.error("Error cargando usuarios.", { error });
-        set({users:[]});
-      }
-    },
-    setUsers: (users: User[]) => set(() => ({ users })),
-  }))
+  persist(
+    devtools((set) => ({
+      users: [],
+      hasHydrated: false,
+      loadUsers: async () => {
+        try {
+          const usersRef = ref(db, "users");
+          onValue(usersRef, (snapshot) => {
+            const data = Object.values(snapshot.val()) as User[] || [];
+    
+            if (data) {
+              set({users: data});
+            } else set({users:[]});
+          });
+        } catch (error) {
+          console.error("Error cargando usuarios.", { error });
+          set({users:[]});
+        }
+      },
+      setUsers: (users: User[]) => set(() => ({ users })),
+      setHasHydrated: (hasHydrated: boolean) => set(() => ({ hasHydrated })),
+    })), {
+      name: 'users-storage',
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+        state?.loadUsers();
+      },
+    }
+  )
 );
-
-useUsersStore.getState().loadUsers()

--- a/src/stores/workgroups/workgroups.store.ts
+++ b/src/stores/workgroups/workgroups.store.ts
@@ -1,37 +1,47 @@
 import { create } from "zustand";
 import { Workgroup } from "../../interfaces/Workgroup";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 import { onValue, ref } from "firebase/database";
 import { db } from "../../firebase/firebase.config";
 
 interface WorkgroupState {
   workgroups: Workgroup[] | null;
+  hasHydrated: boolean;
   loadWorkgroups: () => void;
   setWorkgroups: (workgroup: Workgroup[]) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
 export const useWorkgroupStore = create<WorkgroupState>()(
-  devtools((set) => ({
-    workgroups: [],
-    loadWorkgroups: async () => {
-      try {
-        const usersRef = ref(db, "workgroups");
-        onValue(usersRef, (snapshot) => {
-          const data = Object.values(snapshot.val()) as Workgroup[] || [];
+  persist(
+    devtools((set) => ({
+      workgroups: [],
+      hasHydrated: false,
+      loadWorkgroups: async () => {
+        try {
+          const usersRef = ref(db, "workgroups");
+          onValue(usersRef, (snapshot) => {
+            const data = Object.values(snapshot.val()) as Workgroup[] || [];
 
-          if (data) {
-            set({ workgroups: data });
-          } else set({ workgroups: [] });
-        });
-      } catch (error) {
-        console.error("Error al intentar cargar los grupos de trabajo. ", {
-          error,
-        });
-        set({ workgroups: [] });
-      }
-    },
-    setWorkgroups: (workgroups: Workgroup[]) => set(() => ({ workgroups })),
-  }))
+            if (data) {
+              set({ workgroups: data });
+            } else set({ workgroups: [] });
+          });
+        } catch (error) {
+          console.error("Error al intentar cargar los grupos de trabajo. ", {
+            error,
+          });
+          set({ workgroups: [] });
+        }
+      },
+      setWorkgroups: (workgroups: Workgroup[]) => set(() => ({ workgroups })),
+      setHasHydrated: (hasHydrated: boolean) => set(() => ({ hasHydrated })),
+    })), {
+      name: 'workgroups-storage',
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+        state?.loadWorkgroups();
+      },
+    }
+  )
 );
-
-useWorkgroupStore.getState().loadWorkgroups();


### PR DESCRIPTION
- Add persist middleware to all stores (auth, tasks, workgroups, users, projects)
- Implement hasHydrated flag and onRehydrateStorage callbacks
- Prevent rendering until stores are properly hydrated
- Fix issue where data doesn't load after clearing cache
- Remove debug logs for cleaner production code
- Move Firebase credentials to environment variables for security

This resolves the issue where users had to refresh the page after login to see tasks and other data when browser cache was cleared.